### PR TITLE
Remove RemovedInDjango19Warning about django.forms.util

### DIFF
--- a/app/commons/widgets.py
+++ b/app/commons/widgets.py
@@ -1,4 +1,4 @@
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.forms.widgets import DateTimeInput
 from django.utils import translation
 from django.utils.safestring import mark_safe


### PR DESCRIPTION
```
RemovedInDjango19Warning: The django.forms.util module has been
renamed. Use django.forms.utils instead.
```
