### PR TITLE
Implement websockets for minichat

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Cette commande va vous permettre de créer un compte administrateur, étape indi
 
 Enfin, afin que le site puisse fournir les fichiers statiques nécessaires à son affichage et à son fonctionnement, il convient d'indiquer à Django de collecter ces fichiers statiques depuis les différentes applications qui sont utilisées, et de les réunir dans un répertoire qui sert à... regrouper les fichiers statiques. Magie ! La commande `python app/manage.py collectstatic` fera cela pour vous. Bien entendu, c'est une commande à répéter à chaque fois que vous faites des modifications dans les fichiers statiques. Fastidieux ? Pas tellement : si vous utilisez le serveur de développement de Django (le truc que vous avez lancé avec `python app/manage.py runserver`), vous n'aurez pas à vous en soucier : le serveur de développement de Django est prévu pour aller rechercher les fichiers statiques directement dans leur répertoire d'origine. 
 
+
+#### Minichat
+
+Le minichat requiert un second daemon: omnibusd, afin de gérer les websockets.
+Pour le lancer, il suffit de faire `python app/manage.py omnibusd &`. Cela permet
+au minichat de ne plus dépendre d'un refresh périodique.
+
 ### Les problèmes fréquents et leurs solutions connues
 
 #### Django retourne une erreur à propos de la base de données

--- a/app/minichat/urls.py
+++ b/app/minichat/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns
 from django.conf.urls import url
 from django.core.urlresolvers import reverse_lazy
-from django.views.generic import RedirectView
+from django.views.generic import RedirectView, TemplateView
 from .views import MessageListView, LatestsView, MessagePostView, UsersListView
 from datetime import date
 
@@ -22,6 +22,9 @@ urlpatterns = patterns('',
                        url(r'post/$',
                            MessagePostView.as_view(),
                            name='minichat_post'),
+                       url(r'ws.js$',
+                           TemplateView.as_view(template_name='minichat/websockets.js'),
+                           name='minichat_js'),
                        url(r'users.json$',
                            UsersListView.as_view(),
                            name='minichat_userslist'),

--- a/app/minichat/views.py
+++ b/app/minichat/views.py
@@ -14,6 +14,7 @@ from .forms import MessageForm
 
 from notifications import notify
 from profile.models import ActiveUser
+from omnibus.api import publish
 
 from datetime import date
 import json
@@ -30,7 +31,7 @@ class MessageListView(MonthArchiveView):
     allow_empty = True
     template_name = 'minichat/list.html'
     context_object_name = 'message_list'
-    
+
     def get_context_data(self, **kwargs):
         context = super(MessageListView, self).get_context_data(**kwargs)
         context['date_list'] = Message.objects.dates('date', 'month')
@@ -80,6 +81,7 @@ class MessagePostView(FormView):
         else:
             # Post message
             message.save()
+            publish('minichat', 'new-message')
 
             # Notify users that are anchored in this message
             anchors = message.parse_anchors()
@@ -108,9 +110,9 @@ class LatestsJSONView(View):
         output = []
         for message in messages:
             output.append({
-                'username': message.user.get_username(), 
+                'username': message.user.get_username(),
                 'avatar': message.user.profile.avatar,
-                'text': message.text, 
+                'text': message.text,
                 'timestamp': timegm(message.date.utctimetuple())
             })
 

--- a/app/settings_base.py
+++ b/app/settings_base.py
@@ -52,6 +52,7 @@ TEMPLATE_DIRS = (
 )
 TEMPLATE_CONTEXT_PROCESSORS = (
     'context_processors.global_settings',
+    'omnibus.context_processors.omnibus',
     'django.contrib.auth.context_processors.auth',
     'django.template.context_processors.request',
     'django.core.context_processors.debug',
@@ -74,6 +75,7 @@ INSTALLED_APPS = (
     'django.contrib.humanize',
     'django.contrib.flatpages',
     'captcha',
+    'omnibus',
 
     'profile',
     'slogan',

--- a/app/static/js/minichat.js
+++ b/app/static/js/minichat.js
@@ -12,11 +12,6 @@ var minichat_chars_output = "#minichat_form .minichat-remainingChars";
 function minichat_init_display(content, get_url) {
     minichat_content = content
     minichat_content_url = get_url;
-    
-    if (minichat_content) {
-        setInterval(minichat_refresh, minichat_timer_delay);
-        minichat_refresh();
-    }
 }
 
 function minichat_refresh() {
@@ -45,11 +40,9 @@ function minichat_post_message() {
             $(minichat_button).find('span').removeClass('fa-spinner fa-spin fa-warning btn-warning');
             $(minichat_input_text).val("");
             minichat_update_chars_count();
-            minichat_refresh();
         })
         .fail(function(data) {
             $(minichat_button).find('span').removeClass('fa-spinner fa-spin').addClass('fa-warning');
-            minichat_refresh();
         });
 }
 

--- a/app/templates/__base.html
+++ b/app/templates/__base.html
@@ -28,8 +28,10 @@
             </script>
             <script src="{% static "libs/jquery/dist/jquery.min.js" %}"></script>
             <script src="{% static "js/scripts"|add:static_ext|add:".js" %}?v=150626-2"></script>
-            <script src="{% static "js/minichat"|add:static_ext|add:".js" %}?v=150626"></script>
+            <script src="{% static "js/minichat"|add:static_ext|add:".js" %}?v=151221-1"></script>
             <script src="{% static "js/markup"|add:static_ext|add:".js" %}?v=150627"></script>
+            <script src="{% static "omnibus/omnibus"|add:static_ext|add:".js" %}"></script>
+            <script src="{% url "minichat_js" %}"></script>
         {% endblock javascript %}
         {{ form.media }}
     {% endwith %}

--- a/app/templates/_sidebar.html
+++ b/app/templates/_sidebar.html
@@ -35,14 +35,14 @@
 
             <div id="minichat_content">
                 <p class="text-muted text-center">
-                    <span class="fa fa-spinner fa-spin"></span> Chargement...</p>
+                    <span class="fa fa-spinner fa-spin"></span> Connexion...</p>
             </div>
             {% if user.is_authenticated %}
 
                 <form action="{% url 'minichat_post' %}" class="form-inline" method="post" id="minichat_form">
                     {% csrf_token %}
                     <div class="input-group">
-                        <input name="text" maxlength="150" type="text" class="form-control" placeholder="Nouveau message"/>
+                        <input disabled="disabled" name="text" maxlength="150" type="text" class="form-control" placeholder="Nouveau message"/>
 
                         <span class="input-group-btn">
 

--- a/app/templates/minichat/websockets.js
+++ b/app/templates/minichat/websockets.js
@@ -1,0 +1,23 @@
+var transport = WebSocket;
+var endpoint = '{{ OMNIBUS_ENDPOINT }}';
+var options = {
+    authToken: '{{ OMNIBUS_AUTH_TOKEN }}'
+};
+
+var connection = new Omnibus(transport, endpoint, options);
+var channel = connection.openChannel('minichat');
+
+connection.on(Omnibus.events.CONNECTION_AUTHENTICATED, function(event) {
+    minichat_refresh();
+    input = document.querySelector('#minichat_form input.form-control');
+    if (input) { input.disabled = false; }
+});
+
+connection.on(Omnibus.events.CONNECTION_DISCONNECTED, function(event) {
+    input = document.querySelector('#minichat_form input.form-control');
+    if (input) { input.disabled = true; }
+});
+
+channel.on('new-message', function(event){
+    minichat_refresh();
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
 Django==1.8.7
+django-omnibus==0.2.0
 django-recaptcha==1.0.4
 django-widget-tweaks==1.4.1
 gunicorn==19.4.1
 Markdown==2.6.5
+pyzmq==14.1.1
+sockjs-tornado==1.0.2
+tornado==3.1.1
 whitenoise==2.0.6


### PR DESCRIPTION
Support des websockets pour le minichat avec la librairie Django-Omnibus. Fonctionnel.

Nécéssite un second daemon: "python app/manage.py omnibus.
- [x] rafraichissement du div complet
- [x] gestion des erreurs
- [x] documentation
