### PR TITLE
Remove alternate stylesheets

### DIFF
--- a/app/templates/__base.html
+++ b/app/templates/__base.html
@@ -10,10 +10,8 @@
 
     {% with static_ext=debug|yesno:",.min" %}
         {% block stylesheets %}
-            {% with preferred_theme=user.profile.get_theme|default:THEMES.DEFAULT %}
-                {%for theme, name in THEMES.ALL %}
-                <link href="{% static "css/"|add:theme|add:".css?v=151220" %}" rel="{%if preferred_theme != theme%}alternate {%endif%}stylesheet" title="{{name}}" />
-                {%endfor%}
+            {% with theme=user.profile.get_theme|default:THEMES.DEFAULT %}
+                <link href="{% static "css/"|add:theme|add:".css?v=151220" %}" rel="stylesheet"/>
             {% endwith %}
             <link href="{% static "libs/font-awesome/css/font-awesome.min.css" %}" rel="stylesheet"/>
             <!--[if lt IE 9]>


### PR DESCRIPTION
While alternate stylesheets seemed to be a great idea, they have two
noticeable problems:
1. The browser always loads them, even if they are not used. This is
   annoying because it increases the page size.
2. When you select an alternate stylesheet and you switch page, you are
   back to the original stylesheet, because browser does not save that
   setting.
