### PR TITLE
Use site.domain instead of hardcoding lexpage.net in mails

### DIFF
--- a/app/notifications/templates/notifications/mail_content.txt
+++ b/app/notifications/templates/notifications/mail_content.txt
@@ -6,5 +6,5 @@ Vous avez {{ notifications|length }} notification{{ notifications|pluralize }} e
  - {{ notification.date|date:'d/m' }} : {{ notification.title }}
 {% endfor %}
 
-Rendez-vous sur http://www.lexpage.net pour plus de détails !
+Rendez-vous sur http://{{ site.domain }} pour plus de détails !
 

--- a/app/profile/templates/profile/activation_email.txt
+++ b/app/profile/templates/profile/activation_email.txt
@@ -1,11 +1,11 @@
 Bonjour, 
 
-Pour compléter votre inscription sur le site http://www.lexpage.net, vous 
+Pour compléter votre inscription sur le site http://{{ site.domain }}, vous 
 devez activer votre compte. Vous disposez de {{ expiration_days }} jours 
 pour activer votre compte. 
 
 La procédure d'activation est très simple : il suffit de vous rendre à l'adresse
-http://www.lexpage.net{% url "registration_activate" %} et d'y entrer la clé
+http://{{ site.domain }}{% url "registration_activate" %} et d'y entrer la clé
 d'activation suivante : 
 {{ activation_key }}
 

--- a/app/profile/templates/profile/password_reset_email.txt
+++ b/app/profile/templates/profile/password_reset_email.txt
@@ -1,7 +1,7 @@
 Bonjour, 
 
 Une demande de réinitialisation de votre mot de passe a été enregistrée pour 
-le site Lexpage (http://www.lexpage.net). Si vous êtes bien l'auteur de 
+le site Lexpage (http://{{ site.domain }}). Si vous êtes bien l'auteur de 
 cette demande, suivez les instructions ci-dessous. Dans le cas contraire, vous
 pouvez simplement ignorer cet e-mail.
 
@@ -10,6 +10,6 @@ informer l'administrateur via le site.
 
 Pour continuer la procédure de réinitialisation de votre mot de passe, 
 copier-coller l'adresse suivante dans votre navigateur :
-http://www.lexpage.net{% url 'auth_password_reset_confirm' uidb64=uid token=token %}
+http://{{ site.domain }}{% url 'auth_password_reset_confirm' uidb64=uid token=token %}
 
 A bientôt, sur Lexpage !


### PR DESCRIPTION
We already use that in
https://github.com/AlexandreDecan/Lexpage/blob/master/app/blog/templates/blog/show.html#L41

This PR makes it consistent
