### PR TITLE
Fix websockets reconnection. Fix #140

### DIFF
--- a/app/commons/static/js/websocket_client.js
+++ b/app/commons/static/js/websocket_client.js
@@ -23,7 +23,7 @@ function WebsocketClient(options, $) {
         return websocket_status;
     }
 
-    this.connect = function(uri) {
+    var connect = function(uri) {
         try {
             deferred = $.Deferred();
             ws = new WebSocket(uri);
@@ -36,6 +36,8 @@ function WebsocketClient(options, $) {
             deferred.reject(new Error(err));
         }
     }
+
+    this.connect = connect;
 
     function send_heartbeat() {
         try {
@@ -63,6 +65,7 @@ function WebsocketClient(options, $) {
     function connection_alive() {
         if(!websocket_status) {
             websocket_status = true;
+            console.log('ws connected');
             call_all_callbacks('on_connect');
         }
     }
@@ -70,6 +73,7 @@ function WebsocketClient(options, $) {
     function connection_dead() {
         if(websocket_status) {
             websocket_status = false;
+            console.log('ws closed');
             call_all_callbacks('on_disconnect');
         }
     }
@@ -93,7 +97,7 @@ function WebsocketClient(options, $) {
             var interval = generateInteval(attempts);
             timer = setTimeout(function() {
                 attempts++;
-                this.connect(ws.url);
+                connect(ws.url);
             }, interval);
         }
     }

--- a/app/minichat/static/js/minichat.js
+++ b/app/minichat/static/js/minichat.js
@@ -18,6 +18,7 @@ function minichat_init_display(content, get_url) {
         setInterval(minichat_refresh_fallback, minichat_timer_delay);
         minichat_refresh();
         if (ws_client){
+            ws_client.register('minichat', 'on_connect', minichat_refresh);
             ws_client.register('minichat', 'on_message', minichat_websocket_message_dispatch);
         }
     };

--- a/app/templates/__base.html
+++ b/app/templates/__base.html
@@ -49,7 +49,6 @@
         {% if user.is_authenticated and ENABLE_WEBSOCKET %}
         <script>
             $(document).ready(function() {
-                console.log(ws_client);
                 ws_client.connect('{{ WEBSOCKET_URI }}lexpage?subscribe-broadcast&subscribe-user&echo');
             });
         </script>


### PR DESCRIPTION
Other small simprovements:
- Don't log the websocket object, instead log connections/disconnections.
- Reload minichat on Websocket connection to avoid race conditions
